### PR TITLE
Patrol Planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ https://github.com/osm-extender/osm-extender
 https://github.com/naggyman/osm-mobile  
 https://github.com/dbreakers/groupbuilder  
 https://github.com/dbreakers/ra4osm  
-https://github.com/newcastlescouts/patrolplanner (https://patrolplanner.newcastlescouts.org.uk)
+https://github.com/newcastlescouts/patrolplanner (https://patrolplanner.newcastlescouts.org.uk)  
 
 ## Apps - Bots
 https://github.com/CabotExplorers/CaBot  

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ https://github.com/osm-extender/osm-extender
 https://github.com/naggyman/osm-mobile  
 https://github.com/dbreakers/groupbuilder  
 https://github.com/dbreakers/ra4osm  
+https://github.com/newcastlescouts/patrolplanner (https://patrolplanner.newcastlescouts.org.uk)
 
 ## Apps - Bots
 https://github.com/CabotExplorers/CaBot  
@@ -208,7 +209,7 @@ https://github.com/Danomanic/tss-engage-api
 https://github.com/hippysurfer/scout-records  
 https://github.com/FAC9/scouts-id  
 https://github.com/dbreakers/printeventra  
-https://github.com/dbreakers/sectionrasummary  
+https://github.com/dbreakers/sectionrasummary
 
 ## Tools - Compass Scrapers
 https://github.com/dbreakers/compassread  

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ https://github.com/Danomanic/tss-engage-api
 https://github.com/hippysurfer/scout-records  
 https://github.com/FAC9/scouts-id  
 https://github.com/dbreakers/printeventra  
-https://github.com/dbreakers/sectionrasummary
+https://github.com/dbreakers/sectionrasummary  
 
 ## Tools - Compass Scrapers
 https://github.com/dbreakers/compassread  


### PR DESCRIPTION
Patrol Planner is an experimental free online software by City of Newcastle Scouts allowing leaders to plan and manage their patrols with an intuitive and visual drag/drop interface.

It's free and open source (FOSS), and can be accessed at https://patrolplanner.newcastlescouts.org.uk!
Primary repo: https://github.com/newcastlescouts/patrolplanner

![Demo](https://i.imgur.com/aADnrHa.png)