### PR TITLE
Add links to 1st Gossoms End Scout's github resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ https://github.com/west-sussex-scouts/wsij-wordpress-theme
 https://github.com/surreymagpie/campfire  
 https://github.com/surreymagpie/woggle  
 https://github.com/tobyontour/campfire  
-https://github.com/1st-gossoms-end-scouts/scouts-wordpress-theme
+https://github.com/1st-gossoms-end-scouts/scouts-wordpress-theme  
 
 ## Fun, Challenge, Adventure (2007)
 https://github.com/neades/netherlee-scout-wp-theme  
@@ -307,8 +307,8 @@ https://github.com/scoutstrap
 https://github.com/ScoutsOnline  
 https://github.com/PyScoutsUK  
 https://github.com/scoutr  
-https://github.com/1st-burnham-on-sea-scout-group
-https://github.com/1st-gossoms-end-scouts
+https://github.com/1st-burnham-on-sea-scout-group  
+https://github.com/1st-gossoms-end-scouts  
 https://github.com/1st-Loch-Lomond-Scout-Group  
 https://github.com/NewcastleScouts  
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ https://github.com/west-sussex-scouts/wsij-wordpress-theme
 https://github.com/surreymagpie/campfire  
 https://github.com/surreymagpie/woggle  
 https://github.com/tobyontour/campfire  
+https://github.com/1st-gossoms-end-scouts/scouts-wordpress-theme
 
 ## Fun, Challenge, Adventure (2007)
 https://github.com/neades/netherlee-scout-wp-theme  
@@ -306,7 +307,8 @@ https://github.com/scoutstrap
 https://github.com/ScoutsOnline  
 https://github.com/PyScoutsUK  
 https://github.com/scoutr  
-https://github.com/1st-burnham-on-sea-scout-group  
+https://github.com/1st-burnham-on-sea-scout-group
+https://github.com/1st-gossoms-end-scouts
 https://github.com/1st-Loch-Lomond-Scout-Group  
 https://github.com/NewcastleScouts  
 
@@ -324,7 +326,6 @@ https://github.com/CotswoldScouts
 https://github.com/CheltenhamScouts  
 https://github.com/1st-Abram-Scouts  
 https://github.com/ScoutHost  
-https://github.com/1st-gossoms-end-scouts  
 https://github.com/1st-2nd-Horley-Scouts  
 https://github.com/WiltshireNorthScouts  
 


### PR DESCRIPTION
This PR adds a wordpress theme from 1st Gossoms End Scouts (and moves the organisation link out of currently empty)